### PR TITLE
fix commit hash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <!-- Maven plugins -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <!-- Tor browser version 13.0.15; tor binary version: 0.4.8.11-->
-    <tor-binary.version>d14b422c9c17f2eb9ae74a5078425ca9e00cc557</tor-binary.version>
+    <tor-binary.version>4e38c9d5cc22266fe06cc42578020bc0a50c783f</tor-binary.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
The commit hash in the last PR was for the commit on my repo; the commit in haveno-dex is different, which is reflected in this PR.