### PR TITLE
Replace obfs4proxy with lyrebird

### DIFF
--- a/tor.native/src/main/resources/native/linux/torrc.native
+++ b/tor.native/src/main/resources/native/linux/torrc.native
@@ -2,7 +2,7 @@
 ClientTransportPlugin fte exec ./PluggableTransports/fteproxy.bin --managed
 
 ## obfs4proxy configuration
-ClientTransportPlugin obfs2,obfs3,obfs4,scramblesuit exec ./PluggableTransports/obfs4proxy
+ClientTransportPlugin obfs4 exec ./PluggableTransports/lyrebird
 
 ## meek configuration
 ClientTransportPlugin meek exec ./PluggableTransports/meek-client

--- a/tor.native/src/main/resources/native/osx/torrc.native
+++ b/tor.native/src/main/resources/native/osx/torrc.native
@@ -1,5 +1,5 @@
 ## obfs4proxy configuration
-ClientTransportPlugin obfs2,obfs3,obfs4,scramblesuit exec PluggableTransports/obfs4proxy
+ClientTransportPlugin obfs4 exec PluggableTransports/lyrebird
 
 ## meek configuration
 ClientTransportPlugin meek exec PluggableTransports/meek-client

--- a/tor.native/src/main/resources/native/windows/torrc.native
+++ b/tor.native/src/main/resources/native/windows/torrc.native
@@ -2,7 +2,7 @@
 ClientTransportPlugin fte exec PluggableTransports\fteproxy --managed
 
 ## obfs4proxy configuration
-ClientTransportPlugin obfs2,obfs3,obfs4,scramblesuit exec PluggableTransports\obfs4proxy
+ClientTransportPlugin obfs4 exec PluggableTransports\lyrebird
 
 ## meek configuration
 ClientTransportPlugin meek exec PluggableTransports\terminateprocess-buffer PluggableTransports\meek-client


### PR DESCRIPTION
It was mentioned in https://github.com/haveno-dex/haveno/issues/927 that obfs4proxy is no longer developed, and has been replaced by a fork by the Tor Project renamed to lyrebird in recent tor releases. As lyrebird is already in the newest netlayer versions, all that needs to be changed is the name of the executable in torrc, which is what this PR does. 

obfs2,obfs3, and scramblesuit have also been removed, as they are also deprecated by tor. I am unsure if their mentioning is required for backwards compatibility for other projects, but it is unlikely that this will be an issue for Haveno.